### PR TITLE
Liczby podzielne przez 3

### DIFF
--- a/src/main/java/org/example/NumbersDivisibleByThree.java
+++ b/src/main/java/org/example/NumbersDivisibleByThree.java
@@ -1,0 +1,18 @@
+package org.example;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class NumbersDivisibleByThree {
+
+    public static List<Integer> getNumbersDivisibleByThree(IntStream ints) {
+        List<Integer> intsList = ints
+                .filter(number -> number % 3 == 0)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+        intsList.forEach(System.out::println);
+        return intsList;
+    }
+
+}

--- a/src/test/java/org/example/NumbersDivisibleByThreeTest.java
+++ b/src/test/java/org/example/NumbersDivisibleByThreeTest.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+class NumbersDivisibleByThreeTest {
+
+    @Test
+    void mustGetNumbersDivisibleByThree() {
+        //given
+        IntStream ints = IntStream.of(3, 4, 5, 6, 7, 9, 12);
+        List<Integer> excepted = Arrays.asList(3, 6, 9, 12);
+
+        //when
+        List<Integer> list = NumbersDivisibleByThree.getNumbersDivisibleByThree(ints);
+
+        //then
+        Assertions.assertEquals(excepted, list);
+    }
+}


### PR DESCRIPTION
Napisz program, który dla wszystkich liczb całkowitych z zadanego zakresu, zwraca tylko te, które są podzielne przez 3. Zwrócone liczby powinny zostać wyświetlone na ekran.
Wskazówka: Do wygenerowania ciągu liczb z konkretnego zakresu użyj IntStream, metoda implementująca wymaganie powinna zwracać kolekcję liczb. Do wyświetlenia wyniku użyj Java Stream API.